### PR TITLE
Add link to documentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A package for working with effects like HTTP and animation within [The Elm Architecture][arch].
 
+[Package Documentation](http://package.elm-lang.org/packages/evancz/elm-effects/1.0.0/)
+
 [arch]: https://github.com/evancz/elm-architecture-tutorial/
 
 


### PR DESCRIPTION
Google gives me the source repo, but I really want the docs. It'd be nice to get from one to the other.