### PR TITLE
Expose requestAnimationFrame(), so that other packages can build on it.

### DIFF
--- a/src/Effects.elm
+++ b/src/Effects.elm
@@ -3,6 +3,7 @@ module Effects
     , map, batch
     , Never
     , toTask
+    , requestAnimationFrame
     )
     where
 {-| This module provides all the tools necessary to create modular components
@@ -37,6 +38,10 @@ experience in an issue.
 
 # Running Effects
 @docs toTask, Never
+
+
+# Low-level Functions
+@docs requestAnimationFrame
 -}
 
 
@@ -209,6 +214,15 @@ toTaskHelp address ((combinedTask, tickMessages) as intermediateResult) effect =
                 )
 
 
+{-| Returns a task which, when executed, will use the browser's native
+`requestAnimationFrame()` method to wait until an animation frame is needed.
+The function you provide will then be called, with the `Time` provided by
+`requestAnimationFrame()` as its parameter. The `Task` returned by your
+function will then be immediately executed.
+
+Note that this is a low-level function, intended as a building block for
+higher-level functions. You will typically not need to call this directly.
+-}
 requestAnimationFrame : (Time -> Task.Task Never ()) -> Task.Task Never ()
 requestAnimationFrame =
     Native.Effects.requestAnimationFrame


### PR DESCRIPTION
The purpose of this pull request would be to expose the native `requestAnimationFrame` function, so that it is possible for other packages to build on `requestAnimationFrame` without themselves needing to include native modules directly.

This is the general approach suggested by @laszlopandy in [his comment](https://github.com/elm-lang/package.elm-lang.org/issues/71) on the native review request for [rgrempel/elm-ticker](https://github.com/rgrempel/elm-ticker).

Note that @laszlopandy suggests building on top of [jwmerrill/elm-animation-frame](https://github.com/jwmerrill/elm-animation-frame). However, that would require a larger change -- essentially, duplicating [src/Native/Effects.js](https://github.com/evancz/elm-effects/blob/master/src/Native/Effects.js) from elm-effects. By way of contrast, all that is required in order to build on top of elm-effects is to expose the existing `requestAnimationFrame` function.

If this is not desirable, then I can submit a pull request to jwmerrill/elm-animation-frame instead, with the larger change mentioned above.