### PR TITLE
Update README to recommend polyfilling requestAnimationFrame

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,7 @@ These small examples are set up to clarify the key ideas by progressively introd
   - [List of random GIFs](http://evancz.github.io/elm-architecture-tutorial/examples/7) &mdash; [code](https://github.com/evancz/elm-architecture-tutorial/tree/master/examples/7)
   - [Animating Components](http://evancz.github.io/elm-architecture-tutorial/examples/8) &mdash; [code](https://github.com/evancz/elm-architecture-tutorial/tree/master/examples/8)
 
+
+## Older Browsers
+
+Elm Effects uses [`requestAnimationFrame`](https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame) for animations. To use Elm Effects with browsers which do not have `requestAnimationFrame`, such as Internet Explorer 9, you should polyfill it with something like [`cagosta/requestAnimationFrame`](https://github.com/cagosta/requestAnimationFrame)


### PR DESCRIPTION
Since different JS libraries set different expectations around support for older browsers, I think it'd be good to do what Facebook did with React and explicitly state that polyfilling is the way to go here.