### PR TITLE
Simplify implementation of ignore-function

### DIFF
--- a/src/Effects.elm
+++ b/src/Effects.elm
@@ -216,7 +216,7 @@ requestAnimationFrame =
 
 ignore : Task.Task x a -> Task.Task x ()
 ignore task =
-  task `Task.andThen` always (Task.succeed ())
+  Task.map (always ()) task
 
 
 sequence_ : List (Task.Task x a) -> Task.Task x ()


### PR DESCRIPTION
Was trying to understand implementation of this module. Realizing that `ignore = Task.map (always ())` helped.