### PR TITLE
Make toTaskHelp more efficient by using accumulation

### DIFF
--- a/src/Effects.elm
+++ b/src/Effects.elm
@@ -166,6 +166,7 @@ toTask address effect =
 
         animationReport time =
             tickMessages
+                |> List.reverse
                 |> List.map (\f -> Signal.send address (f time))
                 |> sequence_
 
@@ -200,13 +201,7 @@ toTaskHelp address ((combinedTask, tickMessages) as intermediateResult) effect =
             intermediateResult
 
         Batch effectList ->
-            let
-                (tasks, toMsgLists) =
-                    List.unzip <| List.map (toTaskHelp address intermediateResult) effectList
-            in
-                ( sequence_ tasks
-                , List.concat toMsgLists
-                )
+            List.foldl (Basics.flip (toTaskHelp address)) intermediateResult effectList
 
 
 requestAnimationFrame : (Time -> Task.Task Never ()) -> Task.Task Never ()

--- a/src/Effects.elm
+++ b/src/Effects.elm
@@ -162,7 +162,7 @@ toTask : Signal.Address a -> Effects a -> Task.Task Never ()
 toTask address effect =
     let
         (combinedTask, tickMessages) =
-            toTaskHelp address (Task.succeed (), []) effect
+            toTaskHelp address effect (Task.succeed (), [])
 
         animationReport time =
             tickMessages
@@ -178,10 +178,10 @@ toTask address effect =
 
 toTaskHelp
     : Signal.Address a
-    -> (Task.Task Never (), List (Time -> a))
     -> Effects a
     -> (Task.Task Never (), List (Time -> a))
-toTaskHelp address ((combinedTask, tickMessages) as intermediateResult) effect =
+    -> (Task.Task Never (), List (Time -> a))
+toTaskHelp address effect ((combinedTask, tickMessages) as intermediateResult) =
     case effect of
         Task task ->
             let
@@ -201,7 +201,7 @@ toTaskHelp address ((combinedTask, tickMessages) as intermediateResult) effect =
             intermediateResult
 
         Batch effectList ->
-            List.foldl (Basics.flip (toTaskHelp address)) intermediateResult effectList
+            List.foldl (toTaskHelp address) intermediateResult effectList
 
 
 requestAnimationFrame : (Time -> Task.Task Never ()) -> Task.Task Never ()


### PR DESCRIPTION
This is an alternative to https://github.com/evancz/elm-effects/pull/19. Maybe this is the implementation you originally wanted to write, using an accumulating parameter, in which case the extra parameter of `toTaskHelp` does make sense (contrary to the currently released implementation).

The `List.reverse` is only there to make sure this implementation is exactly semantically equivalent to the currently released implementation (in terms of the order of stuff in the `tickMessages` list), and to that from https://github.com/evancz/elm-effects/pull/19. If that order is not considered relevant, the `List.reverse` could simply be dropped.