### PR TITLE
Correct a link in documentation

### DIFF
--- a/src/Effects.elm
+++ b/src/Effects.elm
@@ -7,8 +7,8 @@ module Effects
     where
 {-| This module provides all the tools necessary to create modular components
 that manage their own effects. **It is very important that you go through
-[this tutorial](https://github.com/evancz/elm-components).** It describes a
-pattern that is crucial for any of these functions to make sense.
+[this tutorial](https://github.com/evancz/elm-architecture-tutorial/).** It
+describes a pattern that is crucial for any of these functions to make sense.
 
 # Basic Effects
 @docs Effects, none, task, tick


### PR DESCRIPTION
This pointed to https://github.com/evancz/elm-components, but that link now simply redirects to https://github.com/evancz/elm-effects, which is not what one wants here.

(Alternatively, and maybe in any case, make sure that https://github.com/evancz/elm-components redirects to https://github.com/evancz/elm-architecture-tutorial, I guess?)