### PR TITLE
Batched tick sending

### DIFF
--- a/src/Effects.elm
+++ b/src/Effects.elm
@@ -210,11 +210,8 @@ singleton a = [ a ]
 
 
 requestTickSending : Signal.Address (List a) -> List (Time -> a) -> Task.Task Never ()
-requestTickSending address tickMessages =
-    Native.Effects.requestAnimationFrame
-        (\time -> tickMessages
-                      |> List.map (\f -> f time)
-                      |> Signal.send address)
+requestTickSending =
+    Native.Effects.requestTickSending
 
 
 ignore : Task.Task x a -> Task.Task x ()

--- a/src/Effects.elm
+++ b/src/Effects.elm
@@ -165,14 +165,10 @@ toTask address effect =
         (combinedTask, tickMessages) =
             toTaskHelp address effect (Task.succeed (), [])
 
-        animationReport time =
+        animationRequests =
             tickMessages
                 |> List.reverse
-                |> List.map (\f -> f time)
-                |> Signal.send address
-
-        animationRequests =
-            requestAnimationFrame animationReport
+                |> requestTickSending address
     in
         if List.isEmpty tickMessages
         then
@@ -213,9 +209,12 @@ singleton : a -> List a
 singleton a = [ a ]
 
 
-requestAnimationFrame : (Time -> Task.Task Never ()) -> Task.Task Never ()
-requestAnimationFrame =
+requestTickSending : Signal.Address (List a) -> List (Time -> a) -> Task.Task Never ()
+requestTickSending address tickMessages =
     Native.Effects.requestAnimationFrame
+        (\time -> tickMessages
+                      |> List.map (\f -> f time)
+                      |> Signal.send address)
 
 
 ignore : Task.Task x a -> Task.Task x ()

--- a/src/Effects.elm
+++ b/src/Effects.elm
@@ -167,7 +167,6 @@ toTask address effect =
 
         animationRequests =
             tickMessages
-                |> List.reverse
                 |> requestTickSending address
     in
         if List.isEmpty tickMessages

--- a/src/Effects.elm
+++ b/src/Effects.elm
@@ -148,7 +148,8 @@ map func effect =
 
 
 {-| Convert an `Effects` into a task that cannot fail. When run, the resulting
-task will send a bunch of messages to the given `Address`.
+task will send a bunch of message lists to the given `Address`. As an invariant,
+no empty list will ever be sent.
 
 Generally speaking, you should not need this function, particularly if you are
 using [start-app](http://package.elm-lang.org/packages/evancz/start-app/latest).
@@ -173,7 +174,11 @@ toTask address effect =
         animationRequests =
             requestAnimationFrame animationReport
     in
-        combinedTask `Task.andThen` always animationRequests
+        if List.isEmpty tickMessages
+        then
+          combinedTask
+        else
+          combinedTask `Task.andThen` always animationRequests
 
 
 toTaskHelp

--- a/src/Native/Effects.js
+++ b/src/Native/Effects.js
@@ -11,15 +11,83 @@ Elm.Native.Effects.make = function(localRuntime) {
 	var Task = Elm.Native.Task.make(localRuntime);
 	var Utils = Elm.Native.Utils.make(localRuntime);
 	var Signal = Elm.Signal.make(localRuntime);
-	var List = Elm.List.make(localRuntime);
+	var List = Elm.Native.List.make(localRuntime);
+
+
+	var NO_REQUEST = 0;
+	var PENDING_REQUEST = 1;
+	var state = NO_REQUEST;
+	var messageArray = [];
+
+
+	function batchedSending(address, tickMessages)
+	{
+		var i = messageArray.length - 1;
+		while (i >= 0)
+		{
+			if (messageArray[i].address === address)
+			{
+				messageArray[i].tickMessages = messageArray[i].tickMessages.concat(List.toArray(tickMessages));
+				break;
+			}
+			i--;
+		}
+		if (i < 0)
+		{
+			messageArray.push({ address: address, tickMessages: List.toArray(tickMessages) });
+		}
+
+		switch (state)
+		{
+			case NO_REQUEST:
+				requestAnimationFrame(sendCallback);
+				state = PENDING_REQUEST;
+				return;
+			case PENDING_REQUEST:
+				state = PENDING_REQUEST;
+		}
+	}
+
+
+	function sendCallback(time)
+	{
+		switch (state)
+		{
+			case NO_REQUEST:
+				// This state should not be possible. How can there be no
+				// request, yet somehow we are actively fulfilling a
+				// request?
+				throw new Error(
+					'Unexpected send callback.\n' +
+					'Please report this to <https://github.com/evancz/elm-effects/issues>.'
+				);
+
+			case PENDING_REQUEST:
+				state = NO_REQUEST;
+				send(time);
+		}
+	}
+
+
+	function send(time)
+	{
+		for (var i = messageArray.length; i--; )
+		{
+			var messages = messageArray[i].tickMessages;
+			for (var j = messages.length; j--; )
+			{
+				messages[j] = messages[j](time);
+			}
+			Task.perform( A2(Signal.send, messageArray[i].address, List.fromArray(messages)) );
+		}
+		messageArray = [];
+	}
 
 
 	function requestTickSending(address, tickMessages)
 	{
 		return Task.asyncFunction(function(callback) {
-			requestAnimationFrame(function(time) {
-				Task.perform( A2(Signal.send, address, A2(List.map, function(f) { return f(time); }, tickMessages)) );
-			});
+			batchedSending(address, tickMessages);
 			callback(Task.succeed(Utils.Tuple0));
 		});
 	}

--- a/src/Native/Effects.js
+++ b/src/Native/Effects.js
@@ -42,7 +42,7 @@ Elm.Native.Effects.make = function(localRuntime) {
 		}
 		if (i < 0)
 		{
-			messageArray.push({ address: address, tickMessages: A3(List.foldl, List.cons, List.Nil, tickMessages) });
+			messageArray.push({ address: address, tickMessages: tickMessages });
 		}
 
 		switch (state)

--- a/src/Native/Effects.js
+++ b/src/Native/Effects.js
@@ -10,20 +10,23 @@ Elm.Native.Effects.make = function(localRuntime) {
 
 	var Task = Elm.Native.Task.make(localRuntime);
 	var Utils = Elm.Native.Utils.make(localRuntime);
+	var Signal = Elm.Signal.make(localRuntime);
+	var List = Elm.List.make(localRuntime);
 
 
-	function raf(timeToTask)
+	function requestTickSending(address, tickMessages)
 	{
 		return Task.asyncFunction(function(callback) {
 			requestAnimationFrame(function(time) {
-				Task.perform(timeToTask(time));
+				Task.perform( A2(Signal.send, address, A2(List.map, function(f) { return f(time); }, tickMessages)) );
 			});
 			callback(Task.succeed(Utils.Tuple0));
 		});
 	}
 
+
 	return localRuntime.Native.Effects.values = {
-		requestAnimationFrame: raf
+		requestTickSending: F2(requestTickSending)
 	};
 
 };

--- a/src/Native/Effects.js
+++ b/src/Native/Effects.js
@@ -35,14 +35,14 @@ Elm.Native.Effects.make = function(localRuntime) {
 		{
 			if (messageArray[i].address === address)
 			{
-				Array.prototype.push.apply(messageArray[i].tickMessages, List.toArray(tickMessages));
+				messageArray[i].tickMessages = A3(List.foldl, List.cons, messageArray[i].tickMessages, tickMessages);
 				break;
 			}
 			i--;
 		}
 		if (i < 0)
 		{
-			messageArray.push({ address: address, tickMessages: List.toArray(tickMessages) });
+			messageArray.push({ address: address, tickMessages: A3(List.foldl, List.cons, List.Nil, tickMessages) });
 		}
 
 		switch (state)
@@ -98,12 +98,11 @@ Elm.Native.Effects.make = function(localRuntime) {
 	{
 		for (var i = messageArray.length; i--; )
 		{
-			var messages = messageArray[i].tickMessages;
-			for (var j = messages.length; j--; )
-			{
-				messages[j] = messages[j](time);
-			}
-			Task.perform( A2(Signal.send, messageArray[i].address, List.fromArray(messages)) );
+			var messages = A3(List.foldl, 
+						F2( function(f, list) { return List.Cons(f(time), list); } ),
+						List.Nil,
+						messageArray[i].tickMessages);
+			Task.perform( A2(Signal.send, messageArray[i].address, messages) );
 		}
 		messageArray = [];
 	}

--- a/src/Native/Effects.js
+++ b/src/Native/Effects.js
@@ -35,7 +35,7 @@ Elm.Native.Effects.make = function(localRuntime) {
 		{
 			if (messageArray[i].address === address)
 			{
-				messageArray[i].tickMessages = messageArray[i].tickMessages.concat(List.toArray(tickMessages));
+				Array.prototype.push.apply(messageArray[i].tickMessages, List.toArray(tickMessages));
 				break;
 			}
 			i--;


### PR DESCRIPTION
This implements what was discussed following [this comment](https://github.com/evancz/elm-effects/pull/20#issuecomment-142069336).

Also related (and possibly could be closed by this PR here): https://github.com/evancz/elm-effects/issues/5 and https://github.com/evancz/elm-effects/pull/13.

Of course, since the type of `toTask` has changed, a new release of `elm-effects` with a major version bump would be necessary.

Also, the use of `elm-effects` in `start-app` would need to be adapted. The relevant PR over there is https://github.com/evancz/start-app/pull/28.
