### PR TITLE
Documentation for batching of ticks

### DIFF
--- a/src/Effects.elm
+++ b/src/Effects.elm
@@ -149,7 +149,10 @@ map func effect =
 
 {-| Convert an `Effects` into a task that cannot fail. When run, the resulting
 task will send a bunch of message lists to the given `Address`. As an invariant,
-no empty list will ever be sent.
+no empty list will ever be sent. Non-singleton lists will only ever be sent for
+effects created with [`tick`](#tick). Those may be batched even over different
+calls to `toTask` with the same `Address`. In such lists, the order of elements
+is not significant.
 
 Generally speaking, you should not need this function, particularly if you are
 using [start-app](http://package.elm-lang.org/packages/evancz/start-app/latest).


### PR DESCRIPTION
Even though `toTask` is only "for experts", it seems reasonable to at least say something about what is going on in terms of tick batching there. Currently, there is no mention of that at all, and in fact the list type in the `Signal.Address` must seem very weird and unmotivated to readers of the documentation. Moreover, knowledge of the batching strategy (its behavior or even just its existence) could get lost in the mists of time, so it's good to have it present in the documentation rather than someone having to later re-engineer information from reading the (Native) source code.