### PR TITLE
Change order in andThen-calls, for efficiency

### DIFF
--- a/src/Effects.elm
+++ b/src/Effects.elm
@@ -172,7 +172,7 @@ toTask address effect =
             combinedTask
 
         else
-            combinedTask `Task.andThen` always (requestTickSending address tickMessages)
+            requestTickSending address tickMessages `Task.andThen` always combinedTask
 
 
 toTaskHelp
@@ -187,7 +187,7 @@ toTaskHelp address effect ((combinedTask, tickMessages) as intermediateResult) =
                 reporter =
                     task `Task.andThen` (\answer -> Signal.send address [answer])
             in
-                ( combinedTask `Task.andThen` always (ignore (Task.spawn reporter))
+                ( ignore (Task.spawn reporter) `Task.andThen` always combinedTask
                 , tickMessages
                 )
 


### PR DESCRIPTION
I'd expect some better efficiency from this, because in my understanding of the implementation of tasks, left-nested `andThen` calls (and the nesting can become arbitrarily deep here due to batching) lead to some overhead. So if, for some `task_0` ... `task_n` that are completely independent and whose order of execution does not matter, one has the choice between running ``( ... ((task_0 `andThen` always task_1) `andThen` always task_2) ... ) `andThen` always task_n`` on the one hand, and ``task_n `andThen` always ( ... always (task_2 `andThen` always (task_1 `andThen` always task_0)) ... )`` on the other hand, then one should choose the latter. That is what this PR effects.