### PR TITLE
call callback with Date.now() in setTimeout for polyfill rAF

### DIFF
--- a/src/Native/Effects.js
+++ b/src/Native/Effects.js
@@ -18,7 +18,7 @@ Elm.Native.Effects.make = function(localRuntime) {
 	var _requestAnimationFrame =
 		typeof requestAnimationFrame !== 'undefined'
 			? requestAnimationFrame
-			: function(cb) { setTimeout(cb, 1000 / 60); }
+			: function(cb) { setTimeout(function() {cb(Date.now())}, 1000 / 60); }
 			;
 
 


### PR DESCRIPTION
The rAF will send Time to the callback, but the setTimeout does not.
Many code depend on the Time when tick.